### PR TITLE
Thanks to Juan Pablo Urrita for finding the airflow python bug

### DIFF
--- a/ch-08/airflow/Dockerfile
+++ b/ch-08/airflow/Dockerfile
@@ -1,4 +1,4 @@
-ARG AIRFLOW_BASE_IMAGE=apache/airflow:2.1.0
+ARG AIRFLOW_BASE_IMAGE=apache/airflow:2.1.0-python3.8
 
 FROM docker.io/${AIRFLOW_BASE_IMAGE}
 

--- a/ch-08/airflow/docker-compose-chapter-end.yaml
+++ b/ch-08/airflow/docker-compose-chapter-end.yaml
@@ -41,7 +41,7 @@
 version: '3'
 x-airflow-common:
   &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.1.0}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.1.0-python3.8}
   volumes:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs

--- a/ch-08/airflow/docker-compose.yaml
+++ b/ch-08/airflow/docker-compose.yaml
@@ -41,7 +41,7 @@
 version: '3'
 x-airflow-common:
   &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.1.0}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.1.0-python3.8}
   volumes:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs


### PR DESCRIPTION
Follow Juan at https://github.com/jpurrutia.

There was a bug with the apache/airflow:2.1.0 container without explicit python version. When it defaulted to latest python it broke the airflow login and made running airflow impossible. 

I have patched the docker-compose.yaml and docker-compose-chapter-end.yaml to reflect these options by default and have also pushed my changes to the pre-built image (https://hub.docker.com/repository/docker/newfrontdocker/apache-airflow-spark).